### PR TITLE
Speed Control CAN Enabled/Disabled

### DIFF
--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
       "title": "FTEX Controller Internal CANOpen protocol",
       "description": "Internal part of the CANOpen protocol for real-time and persistent interaction with the FTEX controller. This protocol works conjointly with the public one. It is just not shared publicly.",
-      "version": "1.4.12"
+      "version": "1.4.11"
   },
   "Master_Slave": {
       "CO_ID_MOTOR_SPEED": {
@@ -765,17 +765,6 @@
                   },
                   "Persistence": "Persistent",
                   "Notes": "The rpm is the internal motor rpm, before gear ratio is applied."
-              },
-              "CO_PARAM_MOTOR_CONFIG_SPEED_CONTROL_ENABLED": {
-                  "Subindex": "0x01",
-                  "Access": "R/W",
-                  "Type": "uint8_t",
-                  "Description": "Enable/Disable the motor based speed control.",
-                  "Valid_Options": [
-                      { "value": 0, "description": "Speed control is disabled" },
-                      { "value": 1, "description": "Speed control is enabled." }
-                  ],
-                  "Persistence": "Persistent"
               },
               "CO_PARAM_MOTOR_CONFIG_SPEED_PID_KP": {
                   "Subindex": "0x10",

--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
       "title": "FTEX Controller Internal CANOpen protocol",
       "description": "Internal part of the CANOpen protocol for real-time and persistent interaction with the FTEX controller. This protocol works conjointly with the public one. It is just not shared publicly.",
-      "version": "1.4.11"
+      "version": "1.4.12"
   },
   "Master_Slave": {
       "CO_ID_MOTOR_SPEED": {
@@ -765,6 +765,17 @@
                   },
                   "Persistence": "Persistent",
                   "Notes": "The rpm is the internal motor rpm, before gear ratio is applied."
+              },
+              "CO_PARAM_MOTOR_CONFIG_SPEED_CONTROL_ENABLED": {
+                  "Subindex": "0x01",
+                  "Access": "R/W",
+                  "Type": "uint8_t",
+                  "Description": "Enable/Disable the motor based speed control.",
+                  "Valid_Options": [
+                      { "value": 0, "description": "Speed control is disabled" },
+                      { "value": 1, "description": "Speed control is enabled." }
+                  ],
+                  "Persistence": "Persistent"
               },
               "CO_PARAM_MOTOR_CONFIG_SPEED_PID_KP": {
                   "Subindex": "0x10",

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
     "title": "FTEX Controller CANOpen protocol",
     "description": "CANOpen protocol for real-time and persistent interaction with the FTEX controller.",
-    "version": "2.4.22"
+    "version": "2.4.23"
   },
   "Communication and memory configuration": {
     "CO_ID_CAN_CONFIG": {
@@ -927,6 +927,18 @@
               "min": 0,
               "max": 99
           },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_SPEED_CONTROL_ENABLE": {
+          "Subindex": "0x01",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Disable/Enabled speed control. This features allows a smoother speed control, especially around the vehicle max speed range.",
+          "Valid_Options": [
+            { "value": 0, "description": "Speed control disabled." },
+            { "value": 1, "description": "Speed control enabled." }
+          ],
           "Persistence": "Persistent",
           "Obfuscation": "True"
         }


### PR DESCRIPTION
This PR introduces a new FTEX Open Protocol feature : Speed control enabled/disabled. This will allow the user to manually enable/disable the speed control during their vehicle tuning process.