### PR TITLE
Powerlock over CAN

### DIFF
--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1128,7 +1128,8 @@
             { "value": 2, "description": "Powerlock off / Key-out signal is sent. The controller will turn off." }
           ],
           "Persistence": "Real-time",
-          "Obfuscation": "True"
+          "Obfuscation": "True",
+          "Notes": "If the vehicle is set to 'Vehicle Always On' by the CO_PARAM_VEHICLE_ON_OFF_CONFIGURATION, the CO_PARAM_VEHICLE_POWERLOCK_SIGNAL can still power off the controller via the value 2: Powerlock off / Key out signal."
         }
       }
     },

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1102,7 +1102,7 @@
     },
     "CO_ID_VEHICLE_ON_OFF_CONFIGURATION": {
       "CANOpen_Index": "0x2023",
-      "Description": "Vehicle power on|off configuration",
+      "Description": "Vehicle power on off configuration",
       "Parameters": {
         "CO_PARAM_VEHICLE_ON_OFF_CONFIGURATION": {
           "Subindex": "0x00",
@@ -1111,20 +1111,21 @@
           "Description": "Get or set the vehicle on off configuration.",
           "Valid_Options": [
             { "value": 0, "description": "Vehicle Always On" },
-            { "value": 1, "description": "Power Lock Signal" }
+            { "value": 1, "description": "Vehicle is using Powerlock / Key-In signal" }
           ],
           "Persistence": "Persistent",
           "Obfuscation": "True",
-          "Notes": "Vehicle Always On: The controller starts as soon as the power is active, without needing a powerlock/key-in signal. Power Lock Signal: The controller powers on when it receives a key-in/powerlock signal."
+          "Notes": "Vehicle Always On: The controller starts as soon as the power is active, without needing a Powerlock / Key-in signal. Powerlock / Key-in Signal: The controller powers on when it receives a Powerlock / Key-in signal."
         },
         "CO_PARAM_VEHICLE_POWERLOCK_SIGNAL": {
           "Subindex": "0x01",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Allow the user to bypass the hardware powerlock signal via direct CANOpen message.",
+          "Description": "Allow the user to bypass the hardware Powerlock / Key-in signal via direct CANOpen message. No CAN wakeup messages are necessary, the bike power state will be updated by simply sending this CANOpen message.",
           "Valid_Options": [
-            { "value": 0, "description": "Default value, no signal is sent. Bike is off" },
-            { "value": 1, "description": "Powerlock signal is sent. Bike is on" }
+            { "value": 0, "description": "Default value, no signal is sent. Bike will remain in its current state, either on or off." },
+            { "value": 1, "description": "Powerlock on / Key-in signal is sent. The controller will turn on." },
+            { "value": 2, "description": "Powerlock off / Key-out signal is sent. The controller will turn off." }
           ],
           "Persistence": "Real-time",
           "Obfuscation": "True"

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1119,7 +1119,7 @@
         },
         "CO_PARAM_VEHICLE_POWERLOCK_SIGNAL": {
           "Subindex": "0x01",
-          "Access": "R/W",
+          "Access": "W",
           "Type": "uint8_t",
           "Description": "Allow the user to bypass the hardware Powerlock / Key-in signal via direct CANOpen message. No CAN wakeup messages are necessary, the bike power state will be updated by simply sending this CANOpen message.",
           "Valid_Options": [

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1116,6 +1116,18 @@
           "Persistence": "Persistent",
           "Obfuscation": "True",
           "Notes": "Vehicle Always On: The controller starts as soon as the power is active, without needing a powerlock/key-in signal. Power Lock Signal: The controller powers on when it receives a key-in/powerlock signal."
+        },
+        "CO_PARAM_VEHICLE_POWERLOCK_SIGNAL": {
+          "Subindex": "0x01",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Allow the user to bypass the hardware powerlock signal via direct CANOpen message.",
+          "Valid_Options": [
+            { "value": 0, "description": "Default value, no signal is sent. Bike is off" },
+            { "value": 1, "description": "Powerlock signal is sent. Bike is on" }
+          ],
+          "Persistence": "Real-time",
+          "Obfuscation": "True"
         }
       }
     },


### PR DESCRIPTION
This PR introduces a new FTEX public parameter : Powerlock over CAN.
This new parameter allows the user to turn on/off his bike, which was previously only doable via hardware powerlock signal.
To turn off the bike, we simply send the 0 value, and to turn it on, we send the 1 value.