### PR TITLE
Phase Shift Fix

### DIFF
--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -1056,12 +1056,12 @@
               "CO_PARAM_MOTOR_CONFIG_HALL_SENSORS_ELECTRICAL_PHASE_SHIFT": {
                   "Subindex": "0x02",
                   "Access": "R/W",
-                  "Type": "uint8_t",
+                  "Type": "int16_t",
                   "Unit": "degrees",
                   "Description": "Electrical phase shift between the low to high transition of signal H1 and the zero crossing of the back EMF induced between phase A and B",
                   "Valid_Range": {
-                      "min": 0,
-                      "max": 255
+                      "min": -360,
+                      "max": 360
                   },
                   "Persistence": "Persistent"
               }

--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -1056,11 +1056,11 @@
               "CO_PARAM_MOTOR_CONFIG_HALL_SENSORS_ELECTRICAL_PHASE_SHIFT": {
                   "Subindex": "0x02",
                   "Access": "R/W",
-                  "Type": "int16_t",
+                  "Type": "uint16_t",
                   "Unit": "degrees",
                   "Description": "Electrical phase shift between the low to high transition of signal H1 and the zero crossing of the back EMF induced between phase A and B",
                   "Valid_Range": {
-                      "min": -360,
+                      "min": 0,
                       "max": 360
                   },
                   "Persistence": "Persistent"

--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
       "title": "FTEX Controller Internal CANOpen protocol",
       "description": "Internal part of the CANOpen protocol for real-time and persistent interaction with the FTEX controller. This protocol works conjointly with the public one. It is just not shared publicly.",
-      "version": "1.4.11"
+      "version": "1.4.12"
   },
   "Master_Slave": {
       "CO_ID_MOTOR_SPEED": {


### PR DESCRIPTION
The phase shift range was incorrect, it should be between 0 and 360, which doesn’t fit in a uint8_t parameter type