### PR TITLE
Phase sequence presets protocol definition

### DIFF
--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
       "title": "FTEX Controller Internal CANOpen protocol",
       "description": "Internal part of the CANOpen protocol for real-time and persistent interaction with the FTEX controller. This protocol works conjointly with the public one. It is just not shared publicly.",
-      "version": "1.4.12"
+      "version": "1.4.13"
   },
   "Master_Slave": {
       "CO_ID_MOTOR_SPEED": {
@@ -1066,6 +1066,22 @@
                   "Persistence": "Persistent"
               }
           }
+      },
+      "CO_ID_MOTOR_PHASE_SEQUENCE_PRESET": {
+          "CANOpen_Index": "0x500B",
+          "Description": "Motor phase sequence preset.",
+          "Parameters": {
+              "CO_PARAM_MOTOR_PHASE_SEQUENCE_PRESET": {
+                  "Subindex": "0x00",
+                  "Access": "R/W",
+                  "Type": "uint8_t",
+                "Description": "Motor phase sequence and current sensor configuration, based on pre-defined presets.",
+                  "Valid_Options": [
+                      { "value": 0, "description": "Configuration: Phase sequence: UVW (Blue-Yellow-Green)." },
+                      { "value": 1, "description": "Configuration: Phase sequence: VUW (Yellow-Blue-Green)." }
+                  ],
+                  "Persistence": "Persistent"
+              }
       }
   },
   "DFU": {

--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -1082,6 +1082,7 @@
                   ],
                   "Persistence": "Persistent"
               }
+          }
       }
   },
   "DFU": {

--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -1067,7 +1067,7 @@
               }
           }
       },
-      "CO_ID_MOTOR_PHASE_SEQUENCE_PRESET": {
+      "CO_ID_MOTOR_PHASE_SEQUENCE_CONFIG": {
           "CANOpen_Index": "0x500B",
           "Description": "Motor phase sequence preset.",
           "Parameters": {
@@ -1075,7 +1075,7 @@
                   "Subindex": "0x00",
                   "Access": "R/W",
                   "Type": "uint8_t",
-                "Description": "Motor phase sequence and current sensor configuration, based on pre-defined presets.",
+                  "Description": "Motor phase sequence and current sensor configuration, based on pre-defined presets.",
                   "Valid_Options": [
                       { "value": 0, "description": "Configuration: Phase sequence: UVW (Blue-Yellow-Green)." },
                       { "value": 1, "description": "Configuration: Phase sequence: VUW (Yellow-Blue-Green)." }


### PR DESCRIPTION
This PR introduces a new internal parameter : Motor phase sequence preset.

This parameter allows the user to change its motor phase sequence based on a pre-defined list of supported presets. As of right now, we only have 2 distinct presets used. The core idea is to add a new preset if a new custom motor phase sequence is required in the future.