### PR TITLE
Adding erase external flash command

### DIFF
--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
       "title": "FTEX Controller Internal CANOpen protocol",
       "description": "Internal part of the CANOpen protocol for real-time and persistent interaction with the FTEX controller. This protocol works conjointly with the public one. It is just not shared publicly.",
-      "version": "1.4.13"
+      "version": "1.4.14"
   },
   "Master_Slave": {
       "CO_ID_MOTOR_SPEED": {
@@ -1097,7 +1097,8 @@
                 "Description": "OTA commands.",
                 "Valid_Options": [
                     { "value": 0, "description": "On standby" },
-                    { "value": 1, "description": "Prepare for file transfer" }
+                    { "value": 1, "description": "Prepare for file transfer" },
+                    { "value": 6, "description": "Deleting the previous firmware file saved in the controller's external flash." }
                 ],
                 "Persistence": "Real-time"
               },

--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -1098,7 +1098,7 @@
                 "Valid_Options": [
                     { "value": 0, "description": "On standby" },
                     { "value": 1, "description": "Prepare for file transfer" },
-                    { "value": 6, "description": "Deleting the previous firmware file saved in the controller's external flash." }
+                    { "value": 2, "description": "Deleting the previous firmware file saved in the controller's external flash." }
                 ],
                 "Persistence": "Real-time"
               },

--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -1098,7 +1098,7 @@
                 "Valid_Options": [
                     { "value": 0, "description": "On standby" },
                     { "value": 1, "description": "Prepare for file transfer" },
-                    { "value": 2, "description": "Deleting the previous firmware file saved in the controller's external flash." }
+                    { "value": 6, "description": "Deleting the previous firmware file saved in the controller's external flash." }
                 ],
                 "Persistence": "Real-time"
               },


### PR DESCRIPTION
This PR introduces a new DFU command to erase the external flash. Sending the command 0x06 over the CAN parameter will trigger an external flash erase process, deleting the firmware file stored in the controller's external flash during the last DFU process.

For retro compatibility reasons, the command needs to be 0x06 since the IoT also uses the same command to wipe the controller's external flash in case there is an error raised by the controller during the DFU process.