### PR TITLE
Torque sensor protocol definition adjustments

### DIFF
--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
     "title": "FTEX Controller CANOpen protocol",
     "description": "CANOpen protocol for real-time and persistent interaction with the FTEX controller.",
-    "version": "2.4.28"
+    "version": "2.5.0"
   },
   "Communication and memory configuration": {
     "CO_ID_CAN_CONFIG": {

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
     "title": "FTEX Controller CANOpen protocol",
     "description": "CANOpen protocol for real-time and persistent interaction with the FTEX controller.",
-    "version": "2.4.27"
+    "version": "2.4.28"
   },
   "Communication and memory configuration": {
     "CO_ID_CAN_CONFIG": {
@@ -290,7 +290,7 @@
           "Subindex": "0x30",
           "Access": "R/W",
           "Type": "uint16_t",
-          "Description": "PAS torque sensor min value (offset), between 0–65535 (0V to 3.3V). Minimum value is 4965 (approx. 0.25V) for safety.",
+          "Description": "PAS torque sensor min value (offset), between 0–65535 (0.25V to 3.05V).",
           "Valid_Range": {
               "min": 4966,
               "max": 65535
@@ -302,33 +302,9 @@
           "Subindex": "0x31",
           "Access": "R/W",
           "Type": "uint16_t",
-          "Description": "PAS torque sensor max value, between 0–65535. Minimum value is 4965 (approx. 0.25V) for safety.",
+          "Description": "PAS torque sensor max value, between 0–65535 (0.25V to 3.05V).",
           "Valid_Range": {
               "min": 4966,
-              "max": 65535
-          },
-          "Persistence": "Persistent",
-          "Obfuscation": "True"
-        },
-        "CO_PARAM_PAS_TORQUE_FILTERING_ACCELERATION_CONFIG": {
-          "Subindex": "0x40",
-          "Access": "R/W",
-          "Type": "uint16_t",
-          "Description": "Low pass filter bandwidth value on torque sensor acceleration. Increasing this value increases the filtering on the input (smoother acceleration), which may help reduce the yo-yo effect sometimes felt from pure PAS torque assistance.",
-          "Valid_Range": {
-              "min": 1,
-              "max": 65535
-          },
-          "Persistence": "Persistent",
-          "Obfuscation": "True"
-        },
-        "CO_PARAM_PAS_TORQUE_FILTERING_DECELERATION_CONFIG": {
-          "Subindex": "0x41",
-          "Access": "R/W",
-          "Type": "uint16_t",
-          "Description": "Low pass filter bandwidth value on torque sensor deceleration. Increasing this value increases the filtering on the input (smoother deceleration), which may help reduce the yo-yo effect sometimes felt from pure PAS torque assistance.",
-          "Valid_Range": {
-              "min": 1,
               "max": 65535
           },
           "Persistence": "Persistent",

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -290,7 +290,7 @@
           "Subindex": "0x30",
           "Access": "R/W",
           "Type": "uint16_t",
-          "Description": "PAS torque sensor min value (offset), between 0–65535 (0V to 3.30V). Minimum value is 4965 (approx. 0.25V) for safety.",
+          "Description": "PAS torque sensor min value (offset), between 0–65535 (0V to 3.30V). Minimum value is 4966 (approx. 0.25V) for safety.",
           "Valid_Range": {
               "min": 4966,
               "max": 65535
@@ -302,7 +302,7 @@
           "Subindex": "0x31",
           "Access": "R/W",
           "Type": "uint16_t",
-          "Description": "PAS torque sensor max value, between 0–65535 (0V to 3.30V). Minimum value is 4965 (approx. 0.25V) for safety.",
+          "Description": "PAS torque sensor max value, between 0–65535 (0V to 3.30V). Minimum value is 4966 (approx. 0.25V) for safety.",
           "Valid_Range": {
               "min": 4966,
               "max": 65535

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -278,7 +278,7 @@
           "Subindex": "0x10",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get/set the number of magnets per rotation of the PAS cadence sensor. Minimum value is 4965 (approx. 0.25V) for safety.",
+          "Description": "Get/set the number of magnets per rotation of the PAS cadence sensor.",
           "Valid_Range": {
               "min": 0,
               "max": 50
@@ -302,7 +302,7 @@
           "Subindex": "0x31",
           "Access": "R/W",
           "Type": "uint16_t",
-          "Description": "PAS torque sensor max value, between 0–65535 (0V to 3.30V). ",
+          "Description": "PAS torque sensor max value, between 0–65535 (0V to 3.30V). Minimum value is 4965 (approx. 0.25V) for safety.",
           "Valid_Range": {
               "min": 4966,
               "max": 65535

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -278,7 +278,7 @@
           "Subindex": "0x10",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get/set the number of magnets per rotation of the PAS cadence sensor.",
+          "Description": "Get/set the number of magnets per rotation of the PAS cadence sensor. Minimum value is 4965 (approx. 0.25V) for safety.",
           "Valid_Range": {
               "min": 0,
               "max": 50
@@ -290,7 +290,7 @@
           "Subindex": "0x30",
           "Access": "R/W",
           "Type": "uint16_t",
-          "Description": "PAS torque sensor min value (offset), between 0–65535 (0.25V to 3.05V).",
+          "Description": "PAS torque sensor min value (offset), between 0–65535 (0V to 3.30V). Minimum value is 4965 (approx. 0.25V) for safety.",
           "Valid_Range": {
               "min": 4966,
               "max": 65535
@@ -302,7 +302,7 @@
           "Subindex": "0x31",
           "Access": "R/W",
           "Type": "uint16_t",
-          "Description": "PAS torque sensor max value, between 0–65535 (0.25V to 3.05V).",
+          "Description": "PAS torque sensor max value, between 0–65535 (0V to 3.30V). ",
           "Valid_Range": {
               "min": 4966,
               "max": 65535


### PR DESCRIPTION
Following FTEX internal firmware changes, 2 torque sensor parameters were removed. The voltage description is also adjusted to reflect more accurately the expected range from the sensor input.