### PR TITLE
add speed control parameters to CAN for mid-drive application

### DIFF
--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -803,7 +803,8 @@
                   "Subindex": "0x13",
                   "Access": "R/W",
                   "Type": "uint8_t",
-                  "Description": "PID Speed control minimum torque will apply to avoid clutch desengagement while the speed control is active",
+		  "Unit": "cNm",
+                  "Description": "PID Speed control minimum torque will be applied to avoid clutch disengagement while the speed control is active",
                   "Valid_Range": {
                       "min": 0,
                       "max": 255

--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
       "title": "FTEX Controller Internal CANOpen protocol",
       "description": "Internal part of the CANOpen protocol for real-time and persistent interaction with the FTEX controller. This protocol works conjointly with the public one. It is just not shared publicly.",
-      "version": "1.4.14"
+      "version": "1.4.15"
   },
   "Master_Slave": {
       "CO_ID_MOTOR_SPEED": {

--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -799,6 +799,17 @@
                   },
                   "Persistence": "Persistent"
               },
+              "CO_PARAM_MOTOR_CONFIG_SPEED_PID_MIMIMUM_TORQUE": {
+                  "Subindex": "0x13",
+                  "Access": "R/W",
+                  "Type": "uint8_t",
+                  "Description": "PID Speed control minimum torque will apply to avoid clutch desengagement while the speed control is active",
+                  "Valid_Range": {
+                      "min": 0,
+                      "max": 255
+                  },
+                  "Persistence": "Persistent"
+              },
               "CO_PARAM_MOTOR_CONFIG_SPEED_PID_FOLDBACK_INTERVAL": {
                   "Subindex": "0x20",
                   "Access": "R/W",
@@ -811,6 +822,17 @@
                   },
                   "Persistence": "Persistent",
                   "Notes": "The rpm is the internal motor rpm, before gear ratio is applied."
+              },
+              "CO_PARAM_MOTOR_CONFIG_SPEED_PID_FOLDBACK_ENABLE": {
+                  "Subindex": "0x21",
+                  "Access": "R/W",
+                  "Type": "uint8_t",
+                  "Description": "Speed foldback enable or disable",
+                  "Valid_Options": [
+                      { "value": 0, "description": "Disabled" },
+                      { "value": 1, "description": "Enabled" }
+                  ],
+                  "Persistence": "Persistent"
               }
           }
       },


### PR DESCRIPTION
two new parameters were added to handle the speed control

1- speed foldback enable/disable to activate the speed foldback function

2- add minimum torque value for speed PID to handle the low speed control situation