### PR TITLE
Bump internal version

### DIFF
--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
       "title": "FTEX Controller Internal CANOpen protocol",
       "description": "Internal part of the CANOpen protocol for real-time and persistent interaction with the FTEX controller. This protocol works conjointly with the public one. It is just not shared publicly.",
-      "version": "1.4.15"
+      "version": "1.4.16"
   },
   "Master_Slave": {
       "CO_ID_MOTOR_SPEED": {


### PR DESCRIPTION
Last change (for CO_PARAM_MOTOR_CONFIG_SPEED_PID_MIMIMUM_TORQUE) did not bump the version