### PR TITLE
PAS Sensor Type Configuration Preset

### DIFF
--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -316,7 +316,7 @@
           "Type": "uint8_t",
           "Description": "PAS sensor type preset.",
           "Valid_Options": [
-            { "value": 0, "description": "Analog input sources preset. The torque sensor, cadence sensor and wheel speed sensor is expected to be all analog signals." },
+            { "value": 0, "description": "Analog/Digital input sources preset. The torque sensor, cadence sensor and wheel speed sensor is expected to be all analog signals. Torque signal is optional, but cadence and wheel speed is required." },
             { "value": 100, "description": "FTEX Custom PAS Sensor Configuration Preset 1 [internal]." }
           ],
           "Persistence": "Persistent",

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
     "title": "FTEX Controller CANOpen protocol",
     "description": "CANOpen protocol for real-time and persistent interaction with the FTEX controller.",
-    "version": "2.5.0"
+    "version": "2.5.1"
   },
   "Communication and memory configuration": {
     "CO_ID_CAN_CONFIG": {
@@ -1482,6 +1482,27 @@
         }
       }
     },
+
+    "CO_ID_PAS_SENSOR_TYPE_PRESET": {
+      "CANOpen_Index": "0x203E",
+      "Description": "Select the PAS sensor type configuration preset. This preset will determine which input source (Analog, UART, CANOpen, etc.) is expected for each PAS sensors.",
+      "Parameters": {
+        "CO_PARAM_PAS_SENSOR_TYPE_PRESET": {
+          "Subindex": "0x00",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "PAS sensor type preset.",
+          "Valid_Options": [
+            { "value": 0, "description": "Analog input sources preset. The torque sensor, cadence sensor and wheel speed sensor is expected to be all analog signals." },
+            { "value": 1, "description": "FTEX CAN protocol. The torque sensor, cadence sensor is expected to be over CANOpen, defined by the FTEX_PAS_CANOpen_protocol.json file. The wheel speed sensor is an analog input. Please, note that this configuration is not available yet." },
+            { "value": 100, "description": "FTEX Custom PAS Sensor Configuration Preset 1 [internal]." }
+          ],
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        }
+      }
+    },
+
     "CO_ID_PAS_SPEED_LIMITS": {
       "CANOpen_Index": "0x201A",
       "Description": "Maximum speed for each PAS level.",

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1482,7 +1482,7 @@
         }
       }
     },
-    "CO_ID_PAS_SENSOR_TYPE_PRESET": {
+    "CO_ID_PAS_WSS_SENSOR_TYPE_PRESET": {
       "CANOpen_Index": "0x203E",
       "Description": "Select the PAS sensor type configuration preset. This preset will determine which input source (Analog, UART, CANOpen, etc.) is expected for each PAS sensors.",
       "Parameters": {

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1482,7 +1482,6 @@
         }
       }
     },
-
     "CO_ID_PAS_SENSOR_TYPE_PRESET": {
       "CANOpen_Index": "0x203E",
       "Description": "Select the PAS sensor type configuration preset. This preset will determine which input source (Analog, UART, CANOpen, etc.) is expected for each PAS sensors.",
@@ -1502,7 +1501,6 @@
         }
       }
     },
-
     "CO_ID_PAS_SPEED_LIMITS": {
       "CANOpen_Index": "0x201A",
       "Description": "Maximum speed for each PAS level.",

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -309,6 +309,18 @@
           },
           "Persistence": "Persistent",
           "Obfuscation": "True"
+        },
+        "CO_PARAM_PAS_SENSOR_TYPE_PRESET": {
+          "Subindex": "0x40",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "PAS sensor type preset.",
+          "Valid_Options": [
+            { "value": 0, "description": "Analog input sources preset. The torque sensor, cadence sensor and wheel speed sensor is expected to be all analog signals." },
+            { "value": 100, "description": "FTEX Custom PAS Sensor Configuration Preset 1 [internal]." }
+          ],
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
         }
       }
     },
@@ -1479,25 +1491,6 @@
           "Persistence": "Persistent",
           "Obfuscation": "True",
           "Notes": "If the selected default PAS level is higher than the max number of levels, the max will be selected instead. If not specified, the default level is 0, which is preferable for safety reasons."
-        }
-      }
-    },
-    "CO_ID_PAS_SENSOR_TYPE_PRESET": {
-      "CANOpen_Index": "0x203E",
-      "Description": "Select the PAS sensor type configuration preset. This preset will determine which input source (Analog, UART, CANOpen, etc.) is expected for each PAS sensors.",
-      "Parameters": {
-        "CO_PARAM_PAS_SENSOR_TYPE_PRESET": {
-          "Subindex": "0x00",
-          "Access": "R/W",
-          "Type": "uint8_t",
-          "Description": "PAS sensor type preset.",
-          "Valid_Options": [
-            { "value": 0, "description": "Analog input sources preset. The torque sensor, cadence sensor and wheel speed sensor is expected to be all analog signals." },
-            { "value": 1, "description": "FTEX CAN protocol. The torque sensor, cadence sensor is expected to be over CANOpen, defined by the FTEX_PAS_CANOpen_protocol.json file. The wheel speed sensor is an analog input. Please, note that this configuration is not available yet." },
-            { "value": 100, "description": "FTEX Custom PAS Sensor Configuration Preset 1 [internal]." }
-          ],
-          "Persistence": "Persistent",
-          "Obfuscation": "True"
         }
       }
     },

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -309,18 +309,6 @@
           },
           "Persistence": "Persistent",
           "Obfuscation": "True"
-        },
-        "CO_PARAM_PAS_SENSOR_TYPE_PRESET": {
-          "Subindex": "0x40",
-          "Access": "R/W",
-          "Type": "uint8_t",
-          "Description": "PAS sensor type preset.",
-          "Valid_Options": [
-            { "value": 0, "description": "Analog/Digital input sources preset. The torque sensor, cadence sensor and wheel speed sensor is expected to be all analog signals. Torque signal is optional, but cadence and wheel speed is required." },
-            { "value": 100, "description": "FTEX Custom PAS Sensor Configuration Preset 1 [internal]." }
-          ],
-          "Persistence": "Persistent",
-          "Obfuscation": "True"
         }
       }
     },
@@ -1491,6 +1479,24 @@
           "Persistence": "Persistent",
           "Obfuscation": "True",
           "Notes": "If the selected default PAS level is higher than the max number of levels, the max will be selected instead. If not specified, the default level is 0, which is preferable for safety reasons."
+        }
+      }
+    },
+    "CO_ID_PAS_SENSOR_TYPE_PRESET": {
+      "CANOpen_Index": "0x203E",
+      "Description": "Select the PAS sensor type configuration preset. This preset will determine which input source (Analog, UART, CANOpen, etc.) is expected for each PAS sensors.",
+      "Parameters": {
+        "CO_PARAM_PAS_SENSOR_TYPE_PRESET": {
+          "Subindex": "0x00",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "PAS sensor type preset.",
+          "Valid_Options": [
+            { "value": 0, "description": "Analog/Digital input sources preset. The torque sensor, cadence sensor and wheel speed sensor are expected to be all analog/digital signals. Torque signal is optional, but cadence and wheel speed are required." },
+            { "value": 100, "description": "FTEX Custom PAS Sensor Configuration Preset 1 [internal]." }
+          ],
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
         }
       }
     },


### PR DESCRIPTION
This PR introduces a new FTEX Public Protocol parameter : CO_ID_PAS_SENSOR_TYPE_PRESET.

This allows the user to quickly change its hardware PAS sensors configuration based of a set of different implemented presets. This is currently used for an internal project.
