### PR TITLE
Split PAS Speed Limits

### DIFF
--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1639,7 +1639,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 1.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 1. The usual configuration would set this value lower than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1652,7 +1652,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 2.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 2. The usual configuration would set this value lower than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1665,7 +1665,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 3.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 3. The usual configuration would set this value lower than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1678,7 +1678,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 4.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 4. The usual configuration would set this value lower than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1691,7 +1691,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 5.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 5. The usual configuration would set this value lower than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1704,7 +1704,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 6.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 6. The usual configuration would set this value lower than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1717,7 +1717,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 7.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 7. The usual configuration would set this value lower than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1730,7 +1730,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 8.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 8. The usual configuration would set this value lower than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1743,7 +1743,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 9.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 9. The usual configuration would set this value lower than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1756,7 +1756,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 0.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 0. The usual configuration would set this value lower than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
     "title": "FTEX Controller CANOpen protocol",
     "description": "CANOpen protocol for real-time and persistent interaction with the FTEX controller.",
-    "version": "2.5.1"
+    "version": "2.5.2"
   },
   "Communication and memory configuration": {
     "CO_ID_CAN_CONFIG": {
@@ -1504,11 +1504,11 @@
       "CANOpen_Index": "0x201A",
       "Description": "Maximum speed for each PAS level.",
       "Parameters": {
-        "CO_PARAM_PAS_SPEED_LEVEL1": {
+        "CO_PARAM_PAS_TORQUE_SPEED_LEVEL1": {
           "Subindex": "0x00",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum speed of PAS level 1.",
+          "Description": "Get or set the maximum torque based speed of PAS level 1.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1516,11 +1516,11 @@
           "Persistence": "Persistent",
           "Obfuscation": "True"
         },
-        "CO_PARAM_PAS_SPEED_LEVEL2": {
+        "CO_PARAM_PAS_TORQUE_SPEED_LEVEL2": {
           "Subindex": "0x01",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum speed of PAS level 2.",
+          "Description": "Get or set the maximum torque based speed of PAS level 2.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1528,11 +1528,11 @@
           "Persistence": "Persistent",
           "Obfuscation": "True"
         },
-        "CO_PARAM_PAS_SPEED_LEVEL3": {
+        "CO_PARAM_PAS_TORQUE_SPEED_LEVEL3": {
           "Subindex": "0x02",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum speed of PAS level 3.",
+          "Description": "Get or set the maximum torque based speed of PAS level 3.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1540,11 +1540,11 @@
           "Persistence": "Persistent",
           "Obfuscation": "True"
         },
-        "CO_PARAM_PAS_SPEED_LEVEL4": {
+        "CO_PARAM_PAS_TORQUE_SPEED_LEVEL4": {
           "Subindex": "0x03",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum speed of PAS level 4.",
+          "Description": "Get or set the maximum torque based speed of PAS level 4.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1552,11 +1552,11 @@
           "Persistence": "Persistent",
           "Obfuscation": "True"
         },
-        "CO_PARAM_PAS_SPEED_LEVEL5": {
+        "CO_PARAM_PAS_TORQUE_SPEED_LEVEL5": {
           "Subindex": "0x04",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum speed of PAS level 5.",
+          "Description": "Get or set the maximum torque based speed of PAS level 5.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1564,11 +1564,11 @@
           "Persistence": "Persistent",
           "Obfuscation": "True"
         },
-        "CO_PARAM_PAS_SPEED_LEVEL6": {
+        "CO_PARAM_PAS_TORQUE_SPEED_LEVEL6": {
           "Subindex": "0x05",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum speed of PAS level 6.",
+          "Description": "Get or set the maximum torque based speed of PAS level 6.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1576,11 +1576,11 @@
           "Persistence": "Persistent",
           "Obfuscation": "True"
         },
-        "CO_PARAM_PAS_SPEED_LEVEL7": {
+        "CO_PARAM_PAS_TORQUE_SPEED_LEVEL7": {
           "Subindex": "0x06",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum speed of PAS level 7.",
+          "Description": "Get or set the maximum torque based speed of PAS level 7.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1588,11 +1588,11 @@
           "Persistence": "Persistent",
           "Obfuscation": "True"
         },
-        "CO_PARAM_PAS_SPEED_LEVEL8": {
+        "CO_PARAM_PAS_TORQUE_SPEED_LEVEL8": {
           "Subindex": "0x07",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum speed of PAS level 8.",
+          "Description": "Get or set the maximum torque based speed of PAS level 8.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1600,11 +1600,11 @@
           "Persistence": "Persistent",
           "Obfuscation": "True"
         },
-        "CO_PARAM_PAS_SPEED_LEVEL9": {
+        "CO_PARAM_PAS_TORQUE_SPEED_LEVEL9": {
           "Subindex": "0x08",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum speed of PAS level 9.",
+          "Description": "Get or set the maximum torque based speed of PAS level 9.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1612,11 +1612,131 @@
           "Persistence": "Persistent",
           "Obfuscation": "True"
         },
-        "CO_PARAM_PAS_SPEED_LEVEL0": {
+        "CO_PARAM_PAS_TORQUE_SPEED_LEVEL0": {
+          "Subindex": "0x09",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Get or set the maximum torque based speed of PAS level 0.",
+          "Valid_Range": {
+              "min": 0,
+              "max": 99
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_PAS_CADENCE_SPEED_LEVEL1": {
           "Subindex": "0x10",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum speed of PAS level 0.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 1.",
+          "Valid_Range": {
+              "min": 0,
+              "max": 99
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_PAS_CADENCE_SPEED_LEVEL2": {
+          "Subindex": "0x11",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Get or set the maximum cadence based speed of PAS level 2.",
+          "Valid_Range": {
+              "min": 0,
+              "max": 99
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_PAS_CADENCE_SPEED_LEVEL3": {
+          "Subindex": "0x12",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Get or set the maximum cadence based speed of PAS level 3.",
+          "Valid_Range": {
+              "min": 0,
+              "max": 99
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_PAS_CADENCE_SPEED_LEVEL4": {
+          "Subindex": "0x13",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Get or set the maximum cadence based speed of PAS level 4.",
+          "Valid_Range": {
+              "min": 0,
+              "max": 99
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_PAS_CADENCE_SPEED_LEVEL5": {
+          "Subindex": "0x14",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Get or set the maximum cadence based speed of PAS level 5.",
+          "Valid_Range": {
+              "min": 0,
+              "max": 99
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_PAS_CADENCE_SPEED_LEVEL6": {
+          "Subindex": "0x15",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Get or set the maximum cadence based speed of PAS level 6.",
+          "Valid_Range": {
+              "min": 0,
+              "max": 99
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_PAS_CADENCE_SPEED_LEVEL7": {
+          "Subindex": "0x16",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Get or set the maximum cadence based speed of PAS level 7.",
+          "Valid_Range": {
+              "min": 0,
+              "max": 99
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_PAS_CADENCE_SPEED_LEVEL8": {
+          "Subindex": "0x17",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Get or set the maximum cadence based speed of PAS level 8.",
+          "Valid_Range": {
+              "min": 0,
+              "max": 99
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_PAS_CADENCE_SPEED_LEVEL9": {
+          "Subindex": "0x18",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Get or set the maximum cadence based speed of PAS level 9.",
+          "Valid_Range": {
+              "min": 0,
+              "max": 99
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_PAS_CADENCE_SPEED_LEVEL0": {
+          "Subindex": "0x19",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Description": "Get or set the maximum cadence based speed of PAS level 0.",
           "Valid_Range": {
               "min": 0,
               "max": 99

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1639,7 +1639,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 1. The usual configuration would set this value lower than its torque counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 1. The usual configuration would set this value lower or equal than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1652,7 +1652,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 2. The usual configuration would set this value lower than its torque counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 2. The usual configuration would set this value lower or equal than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1665,7 +1665,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 3. The usual configuration would set this value lower than its torque counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 3. The usual configuration would set this value lower or equal than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1678,7 +1678,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 4. The usual configuration would set this value lower than its torque counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 4. The usual configuration would set this value lower or equal than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1691,7 +1691,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 5. The usual configuration would set this value lower than its torque counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 5. The usual configuration would set this value lower or equal than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1704,7 +1704,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 6. The usual configuration would set this value lower than its torque counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 6. The usual configuration would set this value lower or equal than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1717,7 +1717,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 7. The usual configuration would set this value lower than its torque counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 7. The usual configuration would set this value lower or equal than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1730,7 +1730,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 8. The usual configuration would set this value lower than its torque counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 8. The usual configuration would set this value lower or equal than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1743,7 +1743,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 9. The usual configuration would set this value lower than its torque counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 9. The usual configuration would set this value lower or equal than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1756,7 +1756,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 0. The usual configuration would set this value lower than its torque counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 0. The usual configuration would set this value lower or equal than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1508,6 +1508,7 @@
           "Subindex": "0x00",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum torque based speed of PAS level 1. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
@@ -1520,6 +1521,7 @@
           "Subindex": "0x01",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum torque based speed of PAS level 2. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
@@ -1532,6 +1534,7 @@
           "Subindex": "0x02",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum torque based speed of PAS level 3. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
@@ -1544,6 +1547,7 @@
           "Subindex": "0x03",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum torque based speed of PAS level 4. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
@@ -1556,6 +1560,7 @@
           "Subindex": "0x04",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum torque based speed of PAS level 5. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
@@ -1568,6 +1573,7 @@
           "Subindex": "0x05",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum torque based speed of PAS level 6. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
@@ -1580,6 +1586,7 @@
           "Subindex": "0x06",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum torque based speed of PAS level 7. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
@@ -1592,6 +1599,7 @@
           "Subindex": "0x07",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum torque based speed of PAS level 8. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
@@ -1604,6 +1612,7 @@
           "Subindex": "0x08",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum torque based speed of PAS level 9. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
@@ -1616,6 +1625,7 @@
           "Subindex": "0x09",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum torque based speed of PAS level 0. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
@@ -1628,6 +1638,7 @@
           "Subindex": "0x10",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum cadence based speed of PAS level 1.",
           "Valid_Range": {
               "min": 0,
@@ -1640,6 +1651,7 @@
           "Subindex": "0x11",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum cadence based speed of PAS level 2.",
           "Valid_Range": {
               "min": 0,
@@ -1652,6 +1664,7 @@
           "Subindex": "0x12",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum cadence based speed of PAS level 3.",
           "Valid_Range": {
               "min": 0,
@@ -1664,6 +1677,7 @@
           "Subindex": "0x13",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum cadence based speed of PAS level 4.",
           "Valid_Range": {
               "min": 0,
@@ -1676,6 +1690,7 @@
           "Subindex": "0x14",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum cadence based speed of PAS level 5.",
           "Valid_Range": {
               "min": 0,
@@ -1688,6 +1703,7 @@
           "Subindex": "0x15",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum cadence based speed of PAS level 6.",
           "Valid_Range": {
               "min": 0,
@@ -1700,6 +1716,7 @@
           "Subindex": "0x16",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum cadence based speed of PAS level 7.",
           "Valid_Range": {
               "min": 0,
@@ -1712,6 +1729,7 @@
           "Subindex": "0x17",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum cadence based speed of PAS level 8.",
           "Valid_Range": {
               "min": 0,
@@ -1724,6 +1742,7 @@
           "Subindex": "0x18",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum cadence based speed of PAS level 9.",
           "Valid_Range": {
               "min": 0,
@@ -1736,6 +1755,7 @@
           "Subindex": "0x19",
           "Access": "R/W",
           "Type": "uint8_t",
+          "Unit": "km/h",
           "Description": "Get or set the maximum cadence based speed of PAS level 0.",
           "Valid_Range": {
               "min": 0,

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1509,7 +1509,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum torque based speed of PAS level 1. The usual configuration would set this value higher than its cadence counter part.",
+          "Description": "Get or set the maximum torque based speed of PAS level 1. The usual configuration would set this value higher than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1522,7 +1522,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum torque based speed of PAS level 2. The usual configuration would set this value higher than its cadence counter part.",
+          "Description": "Get or set the maximum torque based speed of PAS level 2. The usual configuration would set this value higher than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1535,7 +1535,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum torque based speed of PAS level 3. The usual configuration would set this value higher than its cadence counter part.",
+          "Description": "Get or set the maximum torque based speed of PAS level 3. The usual configuration would set this value higher than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1548,7 +1548,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum torque based speed of PAS level 4. The usual configuration would set this value higher than its cadence counter part.",
+          "Description": "Get or set the maximum torque based speed of PAS level 4. The usual configuration would set this value higher than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1561,7 +1561,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum torque based speed of PAS level 5. The usual configuration would set this value higher than its cadence counter part.",
+          "Description": "Get or set the maximum torque based speed of PAS level 5. The usual configuration would set this value higher than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1574,7 +1574,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum torque based speed of PAS level 6. The usual configuration would set this value higher than its cadence counter part.",
+          "Description": "Get or set the maximum torque based speed of PAS level 6. The usual configuration would set this value higher than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1587,7 +1587,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum torque based speed of PAS level 7. The usual configuration would set this value higher than its cadence counter part.",
+          "Description": "Get or set the maximum torque based speed of PAS level 7. The usual configuration would set this value higher than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1600,7 +1600,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum torque based speed of PAS level 8. The usual configuration would set this value higher than its cadence counter part.",
+          "Description": "Get or set the maximum torque based speed of PAS level 8. The usual configuration would set this value higher than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1613,7 +1613,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum torque based speed of PAS level 9. The usual configuration would set this value higher than its cadence counter part.",
+          "Description": "Get or set the maximum torque based speed of PAS level 9. The usual configuration would set this value higher than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1626,7 +1626,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum torque based speed of PAS level 0. The usual configuration would set this value higher than its cadence counter part.",
+          "Description": "Get or set the maximum torque based speed of PAS level 0. The usual configuration would set this value higher than its cadence counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1639,7 +1639,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 1. The usual configuration would set this value lower than its cadence counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 1. The usual configuration would set this value lower than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1652,7 +1652,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 2. The usual configuration would set this value lower than its cadence counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 2. The usual configuration would set this value lower than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1665,7 +1665,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 3. The usual configuration would set this value lower than its cadence counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 3. The usual configuration would set this value lower than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1678,7 +1678,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 4. The usual configuration would set this value lower than its cadence counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 4. The usual configuration would set this value lower than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1691,7 +1691,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 5. The usual configuration would set this value lower than its cadence counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 5. The usual configuration would set this value lower than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1704,7 +1704,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 6. The usual configuration would set this value lower than its cadence counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 6. The usual configuration would set this value lower than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1717,7 +1717,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 7. The usual configuration would set this value lower than its cadence counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 7. The usual configuration would set this value lower than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1730,7 +1730,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 8. The usual configuration would set this value lower than its cadence counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 8. The usual configuration would set this value lower than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1743,7 +1743,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 9. The usual configuration would set this value lower than its cadence counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 9. The usual configuration would set this value lower than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1756,7 +1756,7 @@
           "Access": "R/W",
           "Type": "uint8_t",
           "Unit": "km/h",
-          "Description": "Get or set the maximum cadence based speed of PAS level 0. The usual configuration would set this value lower than its cadence counterpart.",
+          "Description": "Get or set the maximum cadence based speed of PAS level 0. The usual configuration would set this value lower than its torque counterpart.",
           "Valid_Range": {
               "min": 0,
               "max": 99

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -1508,7 +1508,7 @@
           "Subindex": "0x00",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum torque based speed of PAS level 1.",
+          "Description": "Get or set the maximum torque based speed of PAS level 1. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1520,7 +1520,7 @@
           "Subindex": "0x01",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum torque based speed of PAS level 2.",
+          "Description": "Get or set the maximum torque based speed of PAS level 2. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1532,7 +1532,7 @@
           "Subindex": "0x02",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum torque based speed of PAS level 3.",
+          "Description": "Get or set the maximum torque based speed of PAS level 3. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1544,7 +1544,7 @@
           "Subindex": "0x03",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum torque based speed of PAS level 4.",
+          "Description": "Get or set the maximum torque based speed of PAS level 4. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1556,7 +1556,7 @@
           "Subindex": "0x04",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum torque based speed of PAS level 5.",
+          "Description": "Get or set the maximum torque based speed of PAS level 5. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1568,7 +1568,7 @@
           "Subindex": "0x05",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum torque based speed of PAS level 6.",
+          "Description": "Get or set the maximum torque based speed of PAS level 6. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1580,7 +1580,7 @@
           "Subindex": "0x06",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum torque based speed of PAS level 7.",
+          "Description": "Get or set the maximum torque based speed of PAS level 7. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1592,7 +1592,7 @@
           "Subindex": "0x07",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum torque based speed of PAS level 8.",
+          "Description": "Get or set the maximum torque based speed of PAS level 8. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1604,7 +1604,7 @@
           "Subindex": "0x08",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum torque based speed of PAS level 9.",
+          "Description": "Get or set the maximum torque based speed of PAS level 9. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
               "max": 99
@@ -1616,7 +1616,7 @@
           "Subindex": "0x09",
           "Access": "R/W",
           "Type": "uint8_t",
-          "Description": "Get or set the maximum torque based speed of PAS level 0.",
+          "Description": "Get or set the maximum torque based speed of PAS level 0. The usual configuration would set this value higher than its cadence counter part.",
           "Valid_Range": {
               "min": 0,
               "max": 99


### PR DESCRIPTION
This PR introduces a replacement for the previous speed limits per PAS level to 2 new different sets of speed limits based of torque and cadence. Depending on which power source (torque or cadence) is used by the bike, the appropriate speed limit will be applied.