### PR TITLE
Throttle env. ramp up parameter

### DIFF
--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -221,7 +221,7 @@
           "Obfuscation": "True",
           "Notes": "If throttle has priority, then PAS is ignored while throttle is engaged. If PAS has priority, then throttle is ignored while PAS is engaged."
         },
-        "CO_PARAM_THROTTLE_POWER_FILTER_RAMP_UP": {
+        "CO_PARAM_THROTTLE_CONFIG_POWER_FILTER_RAMP_UP": {
           "Subindex": "0x10",
           "Access": "R/W",
           "Type": "uint16_t",

--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
     "title": "FTEX Controller CANOpen protocol",
     "description": "CANOpen protocol for real-time and persistent interaction with the FTEX controller.",
-    "version": "2.7.0"
+    "version": "2.7.1"
   },
   "Communication and memory configuration": {
     "CO_ID_CAN_CONFIG": {
@@ -220,6 +220,19 @@
           "Persistence": "Persistent",
           "Obfuscation": "True",
           "Notes": "If throttle has priority, then PAS is ignored while throttle is engaged. If PAS has priority, then throttle is ignored while PAS is engaged."
+        },
+        "CO_PARAM_THROTTLE_POWER_FILTER_RAMP_UP": {
+          "Subindex": "0x10",
+          "Access": "R/W",
+          "Type": "uint16_t",
+          "Unit": "ms",
+          "Description": "Delay before reaching max torque based power. This delay ramp effect is linear.",
+          "Valid_Range": {
+            "min": 0,
+            "max": 10000
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
         }
       }
     },


### PR DESCRIPTION
This PR introduces a new parameter to the FTEX public protocol : CO_PARAM_THROTTLE_POWER_FILTER_RAMP_UP.

This parameter allows to artificially create an acceleration delay on the throttle based output.