### PR TITLE
fix flux weakening direction

### DIFF
--- a/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
+++ b/FTEX_Controller_Internal_CANOpen/FTEX_Controller_Internal_CANOpen_Protocol.json
@@ -868,10 +868,10 @@
               "CO_PARAM_MOTOR_CONFIG_FLUX_WEAKENING_DIRECTION": {
                   "Subindex": "0x04",
                   "Access": "R/W",
-                  "Type": "uint8_t",
+                  "Type": "int8_t",
                   "Description": "Flux Weakening Direction.",
                   "Valid_Options": [
-                      { "value": 0, "description": "Counterclockwise" },
+                      { "value": -1, "description": "Counterclockwise" },
                       { "value": 1, "description": "Clockwise" }
                   ],
                   "Persistence": "Persistent",


### PR DESCRIPTION
the variable type of flux weakening direction was modified to int8 instead if uint8 to be able to assign -1 for counterclockwise and 1 for clockwise direction. it is actually used by flux weakening logic to set the current direction.