### PR TITLE
Adding low battery SOC threshold configurable

### DIFF
--- a/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
+++ b/FTEX_Controller_Public_CANOpen/FTEX_Controller_CANOpen_Protocol.json
@@ -2,7 +2,7 @@
   "protocol": {
     "title": "FTEX Controller CANOpen protocol",
     "description": "CANOpen protocol for real-time and persistent interaction with the FTEX controller.",
-    "version": "2.7.2"
+    "version": "2.7.3"
   },
   "Communication and memory configuration": {
     "CO_ID_CAN_CONFIG": {
@@ -436,6 +436,19 @@
           "Valid_Range": {
               "min": 2800,
               "max": 8499
+          },
+          "Persistence": "Persistent",
+          "Obfuscation": "True"
+        },
+        "CO_PARAM_BATTERY_CONFIG_LOW_SOC_THRESHOLD": {
+          "Subindex": "0x07",
+          "Access": "R/W",
+          "Type": "uint8_t",
+          "Unit": "%",
+          "Description": "Percentage of battery SOC where the low voltage torque limit mode will be enabled and LOW_BATT error will be raised.",
+          "Valid_Range": {
+              "min": 0,
+              "max": 100
           },
           "Persistence": "Persistent",
           "Obfuscation": "True"


### PR DESCRIPTION
This will allow the user to configure the SOC threshold at what SOC the low voltage torque limit is enabled & low battery error is raised.